### PR TITLE
feat: Backup and restore settings as JSON

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,44 @@
+# Manual Testing Guide
+
+## Feature: Backup & Restore Settings (Issue #2)
+
+### Prerequisites
+
+Load the extension in Chrome:
+
+1. Go to `chrome://extensions`
+2. Enable **Developer mode**
+3. Click **Load unpacked** and select the repo folder
+4. Open the extension settings (click the extension icon → Settings, or right-click → Options)
+
+### Test: Export Settings
+
+1. Configure at least one AI provider (e.g. enter a Groq API key and save)
+2. Go to Settings page
+3. Scroll to the **Backup & Restore** section in the left column
+4. Click **⬇️ Export Settings**
+5. ✅ A JSON file named `tabber-settings-YYYY-MM-DD.json` should download
+6. Open the file — verify it contains your model preferences and provider selection
+7. ✅ Verify API keys are NOT present in the export (only model names, URLs, etc.)
+
+### Test: Import Settings
+
+1. Open the downloaded JSON file in a text editor
+2. Change `defaultProvider` to a different value (e.g. `"openai"`)
+3. Save the file
+4. In Settings, click **⬆️ Import Settings** and select the modified file
+5. ✅ The provider selection should update to reflect the imported value
+6. ✅ A success message "Settings imported! Re-enter your API keys." should appear
+7. ✅ Your API keys should still be there (import does not overwrite them)
+
+### Test: Invalid File
+
+1. Click **⬆️ Import Settings**
+2. Select a non-JSON file or a JSON file without a `settings` key
+3. ✅ An error message "Invalid settings file format" should appear
+
+### Test: Re-import Same File
+
+1. Export settings
+2. Import the same file twice in a row
+3. ✅ Should work both times without errors (file input resets between imports)

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -691,3 +691,10 @@ footer {
     flex-direction: column;
   }
 }
+
+/* Backup & Restore */
+.backup-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -108,6 +108,23 @@
               </label>
             </div>
           </section>
+          <!-- Backup & Restore -->
+          <section class="card" id="backup-section">
+            <h2>Backup & Restore</h2>
+            <p class="description">
+              Export or import your settings (API keys are not included for security)
+            </p>
+            <div class="form-actions backup-actions">
+              <button type="button" class="btn secondary" id="export-settings-btn">
+                ⬇️ Export Settings
+              </button>
+              <button type="button" class="btn secondary" id="import-settings-btn">
+                ⬆️ Import Settings
+              </button>
+              <input type="file" id="import-file-input" accept=".json" style="display: none" />
+            </div>
+            <div class="status hidden" id="backup-status"></div>
+          </section>
         </div>
 
         <!-- Right Column: Provider Settings -->

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -247,6 +247,13 @@ function setupEventListeners() {
       }
     }
   });
+
+  // Backup & Restore
+  document.getElementById('export-settings-btn').addEventListener('click', exportSettings);
+  document.getElementById('import-settings-btn').addEventListener('click', () => {
+    document.getElementById('import-file-input').click();
+  });
+  document.getElementById('import-file-input').addEventListener('change', importSettings);
 }
 
 // Show the settings section for the selected provider
@@ -602,5 +609,102 @@ function updateEnabledToggleState(defaultProvider) {
     switchElement.style.opacity = '1';
     switchElement.style.cursor = 'pointer';
     warningMessage.classList.add('hidden');
+  }
+}
+
+// Export settings to a JSON file (API keys excluded for security)
+async function exportSettings() {
+  try {
+    const settings = await secureStorage.get([
+      'enabled',
+      'defaultProvider',
+      'openaiModel',
+      'claudeModel',
+      'localUrl',
+      'localModel',
+      'localApiFormat',
+      'groqModel',
+      'geminiModel',
+    ]);
+
+    const exportData = {
+      version: '1.0',
+      exportedAt: new Date().toISOString(),
+      note: 'API keys are not included. Re-enter them after importing.',
+      settings,
+    };
+
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `tabber-settings-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+
+    showBackupStatus('✓ Settings exported successfully!', 'success');
+  } catch (error) {
+    logger.error('Export failed:', error);
+    showBackupStatus(`✗ Export failed: ${error.message}`, 'error');
+  }
+}
+
+// Import settings from a JSON file
+async function importSettings(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  // Reset file input so same file can be re-imported
+  e.target.value = '';
+
+  try {
+    const text = await file.text();
+    const importData = JSON.parse(text);
+
+    if (!importData.settings || typeof importData.settings !== 'object') {
+      showBackupStatus('✗ Invalid settings file format', 'error');
+      return;
+    }
+
+    // Only import known safe (non-sensitive) keys
+    const allowedKeys = [
+      'enabled',
+      'defaultProvider',
+      'openaiModel',
+      'claudeModel',
+      'localUrl',
+      'localModel',
+      'localApiFormat',
+      'groqModel',
+      'geminiModel',
+    ];
+
+    const safeSettings = {};
+    for (const key of allowedKeys) {
+      if (Object.hasOwn(importData.settings, key)) {
+        safeSettings[key] = importData.settings[key];
+      }
+    }
+
+    await secureStorage.set(safeSettings);
+    await loadSettings();
+
+    showBackupStatus('✓ Settings imported! Re-enter your API keys.', 'success');
+  } catch (error) {
+    logger.error('Import failed:', error);
+    showBackupStatus(`✗ Import failed: ${error.message}`, 'error');
+  }
+}
+
+// Show status message in the backup section
+function showBackupStatus(message, type) {
+  const status = document.getElementById('backup-status');
+  status.textContent = message;
+  status.className = `status ${type}`;
+
+  if (type === 'success') {
+    setTimeout(() => {
+      status.classList.add('hidden');
+    }, 4000);
   }
 }


### PR DESCRIPTION
Closes #2

## Changes
- Added **Backup & Restore** section to the Settings left column
- **Export**: Downloads all non-sensitive settings (models, URLs, provider selection) as a dated JSON file. API keys are intentionally excluded for security.
- **Import**: Loads a previously exported JSON file and restores settings. API keys are preserved (not overwritten).
- Added `TESTING.md` with manual testing instructions

## Files changed
- `settings/settings.html` — new Backup & Restore card
- `settings/settings.js` — `exportSettings()`, `importSettings()`, `showBackupStatus()` functions
- `settings/settings.css` — backup button layout styles
- `TESTING.md` — manual testing guide