### PR TITLE
feat: Add AI instructions section for custom grouping guidance

### DIFF
--- a/docs/testing-ai-skills.md
+++ b/docs/testing-ai-skills.md
@@ -1,0 +1,55 @@
+# Manual Testing Guide
+
+## Feature: AI Instructions / Skills (Issue #28)
+
+### Prerequisites
+
+Load the extension in Chrome developer mode (see main README).
+Ensure an AI provider is configured and working (test connection passes).
+
+### Test: Save and Verify Instructions
+
+1. Open the Settings page
+2. Find the **AI Instructions** section in the left column
+3. Enter some instructions, e.g.:
+   ```
+   Always group cooking and recipe tabs under 'Food'
+   Never create a group called Misc — use 'Other' instead
+   ```
+4. Click **Save Instructions**
+5. ✅ "Instructions saved!" success message appears
+6. Reload the settings page
+7. ✅ Instructions are still there (persisted in storage)
+
+### Test: Instructions Affect Grouping
+
+1. Save instructions: "Always group any tab about food or recipes under 'Kitchen'"
+2. Enable the extension
+3. Open a new tab and navigate to a food/recipe website (e.g. `allrecipes.com`)
+4. ✅ The tab should be grouped into "Kitchen" or a name influenced by your instructions
+5. Compare behavior with instructions cleared — the AI should use a generic group name without instructions
+
+### Test: Clear Instructions
+
+1. Clear the instructions textarea
+2. Click **Save Instructions**
+3. ✅ Success message appears
+4. Open new tabs — AI behaves without custom guidance (uses default logic)
+
+### Test: Instructions with Existing Rules (Integration)
+
+If custom rules (issue #3) are also implemented:
+
+1. Set a custom rule for `github.com → Development`
+2. Set an instruction: "Always put GitHub tabs in 'Code'"
+3. Open `github.com`
+4. ✅ The rule wins — tab goes to "Development" (rules take priority over AI)
+5. Delete the rule, keep the instruction
+6. Open `github.com` again
+7. ✅ AI uses the instruction — tab likely goes to "Code"
+
+### Test: Long Instructions
+
+1. Enter a very long set of instructions (500+ characters)
+2. Save and reload — ✅ all text persists
+3. Open a tab — ✅ extension still works (doesn't break on large prompts)

--- a/services/ai-service.js
+++ b/services/ai-service.js
@@ -39,18 +39,31 @@ export class AIService {
     // Sanitize tab data before sending to AI
     const sanitizedData = this.sanitizer.sanitizeTabData(title, url);
 
-    const prompt = this.buildPrompt(sanitizedData.title, sanitizedData.url, existingGroups);
+    // Load custom instructions
+    const settings = await secureStorage.get(['customInstructions']);
+    const customInstructions = settings.customInstructions || '';
+
+    const prompt = this.buildPrompt(
+      sanitizedData.title,
+      sanitizedData.url,
+      existingGroups,
+      customInstructions
+    );
     const response = await provider.complete(prompt);
 
     return this.parseResponse(response);
   }
 
   // Build the prompt for the AI
-  buildPrompt(title, url, existingGroups) {
+  buildPrompt(title, url, existingGroups, customInstructions = '') {
     const groupList =
       existingGroups.length > 0
         ? existingGroups.map((g) => `- "${g.title}" (${g.color})`).join('\n')
         : 'No existing groups';
+
+    const userInstructionsSection = customInstructions.trim()
+      ? `\nUSER INSTRUCTIONS (follow these carefully):\n${customInstructions.trim()}\n`
+      : '';
 
     return `You are a tab organization assistant. Analyze the following browser tab and decide how to group it.
 
@@ -76,7 +89,7 @@ INSTRUCTIONS:
    - cyan: News, articles, reading
    - orange: Work, business, professional
    - grey: Utilities, settings, misc
-
+${userInstructionsSection}
 Respond ONLY with valid JSON in this exact format:
 {"groupName": "Group Name", "color": "colorname"}
 

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -691,3 +691,27 @@ footer {
     flex-direction: column;
   }
 }
+
+/* AI Instructions */
+.form-group textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: rgb(0, 0, 0, 0.3);
+  border: 1px solid rgb(255, 255, 255, 0.15);
+  border-radius: 8px;
+  color: #f4f4f5;
+  font-size: 0.85rem;
+  font-family: inherit;
+  resize: vertical;
+  transition: border-color 0.2s;
+  line-height: 1.5;
+}
+
+.form-group textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+}
+
+.form-group textarea::placeholder {
+  color: #52525b;
+}

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -46,6 +46,29 @@
             </div>
           </section>
 
+          <!-- AI Instructions -->
+          <section class="card" id="ai-instructions-section">
+            <h2>AI Instructions</h2>
+            <p class="description">
+              Customize how the AI groups your tabs. Write natural-language instructions that will
+              be included in every grouping request.
+            </p>
+            <div class="form-group">
+              <label for="custom-instructions">Custom Instructions</label>
+              <textarea
+                id="custom-instructions"
+                rows="5"
+                placeholder="Examples:&#10;- Always group cooking and recipe tabs under 'Food'&#10;- Never create a group called Misc, use 'Other' instead&#10;- Keep work-related tabs in 'Work' even on weekends"
+              ></textarea>
+            </div>
+            <div class="form-actions">
+              <button type="button" class="btn primary" id="save-instructions-btn">
+                Save Instructions
+              </button>
+              <div class="status hidden" id="instructions-status"></div>
+            </div>
+          </section>
+
           <!-- Provider Selection -->
           <section class="card">
             <h2>AI Provider</h2>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -59,6 +59,7 @@ async function loadSettings() {
     'groqModel',
     'geminiKey',
     'geminiModel',
+    'customInstructions',
   ]);
 
   // Set enabled toggle
@@ -124,6 +125,9 @@ async function loadSettings() {
   } else {
     geminiSelect.value = geminiModel;
   }
+
+  // Set custom instructions
+  document.getElementById('custom-instructions').value = settings.customInstructions || '';
 
   // Update default provider UI - pass actual saved default, not the fallback
   updateDefaultProviderUI(settings.defaultProvider);
@@ -247,6 +251,9 @@ function setupEventListeners() {
       }
     }
   });
+
+  // AI Instructions
+  document.getElementById('save-instructions-btn').addEventListener('click', saveInstructions);
 }
 
 // Show the settings section for the selected provider
@@ -602,5 +609,28 @@ function updateEnabledToggleState(defaultProvider) {
     switchElement.style.opacity = '1';
     switchElement.style.cursor = 'pointer';
     warningMessage.classList.add('hidden');
+  }
+}
+
+// Save custom AI instructions
+async function saveInstructions() {
+  const instructions = document.getElementById('custom-instructions').value;
+
+  try {
+    await secureStorage.set({ customInstructions: instructions });
+    logger.log('Custom instructions saved');
+
+    const status = document.getElementById('instructions-status');
+    status.textContent = '✓ Instructions saved!';
+    status.className = 'status success';
+
+    setTimeout(() => {
+      status.classList.add('hidden');
+    }, 3000);
+  } catch (error) {
+    logger.error('Failed to save instructions:', error);
+    const status = document.getElementById('instructions-status');
+    status.textContent = `✗ Save failed: ${error.message}`;
+    status.className = 'status error';
   }
 }


### PR DESCRIPTION
Closes #28

## Changes

### Modified: `services/ai-service.js`
- `getGroupingDecision()` now loads `customInstructions` from storage and passes to `buildPrompt()`
- `buildPrompt()` accepts an optional `customInstructions` parameter — appended to the prompt under a `USER INSTRUCTIONS` section if non-empty
- Fully backward compatible (parameter defaults to empty string)

### Modified: `settings/settings.html`
New **AI Instructions** card in the left column with a resizable textarea and Save button.

### Modified: `settings/settings.js`
- `loadSettings()` now loads and populates `customInstructions`
- `saveInstructions()` function saves textarea value to storage

### Modified: `settings/settings.css`
Textarea styles consistent with existing form inputs.

### New file: `docs/testing-ai-skills.md`
Manual testing guide.

## How it works
User writes natural-language instructions in Settings. On every tab grouping request, those instructions are appended to the AI prompt under a `USER INSTRUCTIONS` section. If empty, the prompt is unchanged.