### PR TITLE
feat: Add custom rules for deterministic tab grouping

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,6 +3,7 @@
 import { AIService } from './services/ai-service.js';
 import { secureStorage } from './services/secure-storage.js';
 import { logger } from './services/logger.js';
+import { rulesService } from './services/rules-service.js';
 
 const aiService = new AIService();
 
@@ -65,6 +66,18 @@ async function processTab(tabId, tab, force = false) {
 
     // Get existing groups in this window
     const existingGroups = await getExistingGroups(tab.windowId);
+
+    // Check custom rules first (no API call needed)
+    const ruleMatch = await rulesService.matchTab(tab.title, tab.url);
+    if (ruleMatch) {
+      await executeGrouping(
+        tabId,
+        tab.windowId,
+        { groupName: ruleMatch.groupName, color: ruleMatch.color },
+        existingGroups
+      );
+      return;
+    }
 
     // Ask AI for grouping decision
     const decision = await aiService.getGroupingDecision(tab.title, tab.url, existingGroups);

--- a/docs/testing-custom-rules.md
+++ b/docs/testing-custom-rules.md
@@ -1,0 +1,53 @@
+# Manual Testing Guide
+
+## Feature: Custom Rules (Issue #3)
+
+### Prerequisites
+
+Load the extension in Chrome developer mode (see main README).
+Open extension settings.
+
+### Test: Add a Domain Rule
+
+1. Open the Settings page
+2. Find the **Custom Rules** section
+3. Select **Domain** from the match type dropdown
+4. Enter `github.com` in the match value field
+5. Enter `Development` as the group name
+6. Select `Blue` as the color
+7. Click **Add**
+8. ✅ The rule should appear in the rules list below the form
+9. Open a new tab and navigate to `https://github.com/anything`
+10. ✅ The tab should be grouped into a "Development" group (blue) WITHOUT an AI API call
+
+### Test: Add a URL Contains Rule
+
+1. Add a rule: **URL contains** `youtube` → `Videos` (red)
+2. Open a new tab and go to `https://www.youtube.com`
+3. ✅ Should be grouped into "Videos" (red) immediately
+
+### Test: Add a Title Contains Rule
+
+1. Add a rule: **Title contains** `docs` → `Documentation` (purple)
+2. Open a new tab and navigate to any page with "docs" in the title
+3. ✅ Should be grouped into "Documentation" (purple)
+
+### Test: Rule Takes Priority Over AI
+
+1. Ensure AI is configured and enabled
+2. Add a rule for a domain you know the AI would group differently
+3. Open a tab for that domain
+4. ✅ The rule's group name should be used, not the AI's suggestion
+
+### Test: Delete a Rule
+
+1. Click **✕** on any existing rule
+2. ✅ Rule is removed from the list immediately
+3. Open a tab that would have matched the deleted rule
+4. ✅ AI is now invoked for that tab (rule no longer applies)
+
+### Test: No Rules
+
+1. Delete all rules
+2. ✅ "No rules yet. Add one above." message appears
+3. ✅ AI grouping still works normally

--- a/services/rules-service.js
+++ b/services/rules-service.js
@@ -1,0 +1,79 @@
+// Rules Service - Manages custom tab grouping rules
+// Rules are checked before the AI to provide deterministic, cost-free grouping
+
+import { secureStorage } from './secure-storage.js';
+import { logger } from './logger.js';
+
+const RULES_KEY = 'customRules';
+
+export const rulesService = {
+  // Get all saved rules
+  async getRules() {
+    const settings = await secureStorage.get([RULES_KEY]);
+    return settings[RULES_KEY] || [];
+  },
+
+  // Save the full rules array
+  async saveRules(rules) {
+    await secureStorage.set({ [RULES_KEY]: rules });
+    logger.log(`Rules saved: ${rules.length} rule(s)`);
+  },
+
+  // Add a new rule
+  async addRule(rule) {
+    const rules = await this.getRules();
+    const newRule = {
+      id: Date.now().toString(),
+      ...rule,
+    };
+    rules.push(newRule);
+    await this.saveRules(rules);
+    return newRule;
+  },
+
+  // Delete a rule by id
+  async deleteRule(id) {
+    const rules = await this.getRules();
+    const filtered = rules.filter((r) => r.id !== id);
+    await this.saveRules(filtered);
+  },
+
+  // Check if a tab matches any rule; returns the matching rule or null
+  async matchTab(title, url) {
+    const rules = await this.getRules();
+    const lowerUrl = (url || '').toLowerCase();
+    const lowerTitle = (title || '').toLowerCase();
+
+    for (const rule of rules) {
+      const value = rule.matchValue.toLowerCase();
+
+      let matched = false;
+      switch (rule.matchType) {
+        case 'domain': {
+          try {
+            const hostname = new URL(url || '').hostname.toLowerCase();
+            matched = hostname === value || hostname.endsWith(`.${value}`);
+          } catch {
+            matched = false;
+          }
+          break;
+        }
+        case 'urlContains':
+          matched = lowerUrl.includes(value);
+          break;
+        case 'titleContains':
+          matched = lowerTitle.includes(value);
+          break;
+        default:
+          matched = false;
+      }
+
+      if (matched) {
+        logger.log(`Rule matched: "${rule.groupName}" for "${title}"`);
+        return rule;
+      }
+    }
+
+    return null;
+  },
+};

--- a/settings/settings.css
+++ b/settings/settings.css
@@ -691,3 +691,158 @@ footer {
     flex-direction: column;
   }
 }
+
+/* Custom Rules */
+#rules-section {
+  margin-bottom: 1.5rem;
+}
+
+.rules-form {
+  margin-bottom: 1rem;
+}
+
+.rules-form-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.rules-form-row select,
+.rules-form-row input[type='text'] {
+  flex: 1;
+  min-width: 120px;
+  padding: 0.6rem 0.75rem;
+  background: rgb(0, 0, 0, 0.3);
+  border: 1px solid rgb(255, 255, 255, 0.15);
+  border-radius: 8px;
+  color: #f4f4f5;
+  font-size: 0.85rem;
+}
+
+.rules-form-row select:focus,
+.rules-form-row input[type='text']:focus {
+  outline: none;
+  border-color: #6366f1;
+}
+
+.rules-arrow {
+  color: #a1a1aa;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.rules-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.rules-empty {
+  color: #71717a;
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+.rule-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  background: rgb(255, 255, 255, 0.04);
+  border: 1px solid rgb(255, 255, 255, 0.08);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.rule-match-type {
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  background: rgb(255, 255, 255, 0.08);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.rule-match-value {
+  color: #e4e4e7;
+  font-family: monospace;
+  flex: 1;
+  min-width: 80px;
+}
+
+.rule-group {
+  color: #60a5fa;
+  font-weight: 500;
+}
+
+.rule-color-badge {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  text-transform: capitalize;
+}
+
+.rule-color-blue {
+  background: rgb(59, 130, 246, 0.2);
+  color: #60a5fa;
+}
+
+.rule-color-red {
+  background: rgb(239, 68, 68, 0.2);
+  color: #f87171;
+}
+
+.rule-color-yellow {
+  background: rgb(234, 179, 8, 0.2);
+  color: #facc15;
+}
+
+.rule-color-green {
+  background: rgb(34, 197, 94, 0.2);
+  color: #4ade80;
+}
+
+.rule-color-pink {
+  background: rgb(236, 72, 153, 0.2);
+  color: #f472b6;
+}
+
+.rule-color-purple {
+  background: rgb(168, 85, 247, 0.2);
+  color: #c084fc;
+}
+
+.rule-color-cyan {
+  background: rgb(6, 182, 212, 0.2);
+  color: #22d3ee;
+}
+
+.rule-color-orange {
+  background: rgb(249, 115, 22, 0.2);
+  color: #fb923c;
+}
+
+.rule-color-grey {
+  background: rgb(113, 113, 122, 0.2);
+  color: #a1a1aa;
+}
+
+.rule-delete-btn {
+  background: transparent;
+  border: 1px solid rgb(239, 68, 68, 0.3);
+  color: #f87171;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.rule-delete-btn:hover {
+  background: rgb(239, 68, 68, 0.15);
+}

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -113,6 +113,46 @@
         <!-- Right Column: Provider Settings -->
         <div class="right-column">
           <div class="provider-settings-container">
+            <!-- Custom Rules Section -->
+            <section class="card" id="rules-section">
+              <h2>Custom Rules</h2>
+              <p class="description">
+                Define rules to group tabs automatically — no AI call needed. Rules are checked
+                first, in order.
+              </p>
+
+              <!-- Add Rule Form -->
+              <div class="rules-form">
+                <div class="rules-form-row">
+                  <select id="rule-match-type">
+                    <option value="domain">Domain</option>
+                    <option value="urlContains">URL contains</option>
+                    <option value="titleContains">Title contains</option>
+                  </select>
+                  <input type="text" id="rule-match-value" placeholder="e.g. github.com" />
+                  <span class="rules-arrow">→</span>
+                  <input type="text" id="rule-group-name" placeholder="Group name" />
+                  <select id="rule-color">
+                    <option value="blue">🔵 Blue</option>
+                    <option value="red">🔴 Red</option>
+                    <option value="yellow">🟡 Yellow</option>
+                    <option value="green">🟢 Green</option>
+                    <option value="pink">🩷 Pink</option>
+                    <option value="purple">🟣 Purple</option>
+                    <option value="cyan">🩵 Cyan</option>
+                    <option value="orange">🟠 Orange</option>
+                    <option value="grey">⚫ Grey</option>
+                  </select>
+                  <button type="button" class="btn primary" id="add-rule-btn">Add</button>
+                </div>
+              </div>
+
+              <!-- Rules List -->
+              <div id="rules-list" class="rules-list">
+                <p class="rules-empty hidden" id="rules-empty">No rules yet. Add one above.</p>
+              </div>
+            </section>
+
             <!-- Claude/Anthropic Settings -->
             <section class="card provider-settings" id="claude-settings">
               <h2>Claude Configuration</h2>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -3,6 +3,7 @@
 
 import { secureStorage } from '../services/secure-storage.js';
 import { logger } from '../services/logger.js';
+import { rulesService } from '../services/rules-service.js';
 import {
   loadCachedModels,
   isCustomModel,
@@ -128,6 +129,8 @@ async function loadSettings() {
   // Update default provider UI - pass actual saved default, not the fallback
   updateDefaultProviderUI(settings.defaultProvider);
 
+  await loadRules();
+
   logger.log('loadSettings - defaultProvider:', settings.defaultProvider);
 
   // Update enabled toggle state based on default provider
@@ -232,6 +235,9 @@ function setupEventListeners() {
   document
     .getElementById('local-model')
     .addEventListener('input', () => updateDefaultButtonState('local'));
+
+  // Custom rules
+  document.getElementById('add-rule-btn').addEventListener('click', addRule);
 
   // Listen for storage changes to sync with popup
   chrome.storage.onChanged.addListener((changes, areaName) => {
@@ -602,5 +608,105 @@ function updateEnabledToggleState(defaultProvider) {
     switchElement.style.opacity = '1';
     switchElement.style.cursor = 'pointer';
     warningMessage.classList.add('hidden');
+  }
+}
+
+// Load and render the custom rules list
+async function loadRules() {
+  const rules = await rulesService.getRules();
+  renderRules(rules);
+}
+
+// Render the rules list in the UI
+function renderRules(rules) {
+  const list = document.getElementById('rules-list');
+  const empty = document.getElementById('rules-empty');
+
+  // Remove existing rule rows (keep the empty message)
+  list.querySelectorAll('.rule-row').forEach((el) => el.remove());
+
+  if (rules.length === 0) {
+    empty.classList.remove('hidden');
+    return;
+  }
+
+  empty.classList.add('hidden');
+
+  for (const rule of rules) {
+    const row = document.createElement('div');
+    row.className = 'rule-row';
+    row.dataset.id = rule.id;
+
+    const matchLabel =
+      { domain: 'Domain', urlContains: 'URL contains', titleContains: 'Title contains' }[
+        rule.matchType
+      ] || rule.matchType;
+
+    row.innerHTML = `
+      <span class="rule-match-type">${matchLabel}</span>
+      <span class="rule-match-value">${escapeHtml(rule.matchValue)}</span>
+      <span class="rules-arrow">→</span>
+      <span class="rule-group">${escapeHtml(rule.groupName)}</span>
+      <span class="rule-color-badge rule-color-${rule.color}">${rule.color}</span>
+      <button type="button" class="btn rule-delete-btn" data-id="${rule.id}" aria-label="Delete rule">✕</button>
+    `;
+
+    row.querySelector('.rule-delete-btn').addEventListener('click', async (e) => {
+      const id = e.currentTarget.dataset.id;
+      await rulesService.deleteRule(id);
+      await loadRules();
+    });
+
+    list.appendChild(row);
+  }
+}
+
+// Add a new rule from the form inputs
+async function addRule() {
+  const matchType = document.getElementById('rule-match-type').value;
+  const matchValue = document.getElementById('rule-match-value').value.trim();
+  const groupName = document.getElementById('rule-group-name').value.trim();
+  const color = document.getElementById('rule-color').value;
+
+  if (!matchValue || !groupName) {
+    showRulesStatus('Please fill in the match value and group name', 'error');
+    return;
+  }
+
+  await rulesService.addRule({ matchType, matchValue, groupName, color });
+
+  // Reset form
+  document.getElementById('rule-match-value').value = '';
+  document.getElementById('rule-group-name').value = '';
+
+  await loadRules();
+  showRulesStatus('✓ Rule added', 'success');
+}
+
+// Escape HTML for safe rendering
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Show status in rules section
+function showRulesStatus(message, type) {
+  const section = document.getElementById('rules-section');
+  let statusEl = section.querySelector('.rules-status');
+  if (!statusEl) {
+    statusEl = document.createElement('div');
+    statusEl.className = 'rules-status status';
+    section.appendChild(statusEl);
+  }
+  statusEl.textContent = message;
+  statusEl.className = `rules-status status ${type}`;
+
+  if (type === 'success') {
+    setTimeout(() => {
+      statusEl.classList.add('hidden');
+    }, 3000);
   }
 }


### PR DESCRIPTION
Closes #3

## Changes

### New file: `services/rules-service.js`
A service that stores, loads, and matches custom rules. Rules support three match types: domain, URL contains, and title contains.

### Modified: `background.js`
Rules are checked before the AI call in `processTab()`. If a rule matches, the tab is grouped immediately with no API call.

### Modified: `settings/settings.html`
New **Custom Rules** card in the right column above provider settings. Includes a form to add rules and a live list with delete buttons.

### Modified: `settings/settings.js`
Loads and renders rules on page load. Handles add/delete interactions.

### Modified: `settings/settings.css`
Styles for the rules form, rule rows, and color badges.

### New file: `docs/testing-custom-rules.md`
Manual testing guide.

## How it works
```
Tab opens → check custom rules (no API cost)
  ↓ match found → assign group immediately
  ↓ no match → call AI as normal
```