### PR TITLE
chore: Release v1.1.0

### DIFF
--- a/.changeset/1770325244603-feat-add-changeset-workflow-with-pre-push-validati.md
+++ b/.changeset/1770325244603-feat-add-changeset-workflow-with-pre-push-validati.md
@@ -1,7 +1,0 @@
----
-type: feat
-date: 2026-02-05T21:00:44.604Z
-branch: feat/add-changeset-workflow
----
-
-feat: Add changeset workflow with pre-push validation

--- a/.changeset/1772726333125-refactor-ai-tab-grouping-flow-settings-ux-and-arch.md
+++ b/.changeset/1772726333125-refactor-ai-tab-grouping-flow-settings-ux-and-arch.md
@@ -1,7 +1,0 @@
----
-type: refactor
-date: 2026-03-05T15:58:53.125Z
-branch: feat/ai-grouping-refactor
----
-
-Refactor AI tab grouping flow, settings UX, and architecture

--- a/.changeset/1772728868934-feat-add-ungroup-all-functionality.md
+++ b/.changeset/1772728868934-feat-add-ungroup-all-functionality.md
@@ -1,7 +1,0 @@
----
-type: feat
-date: 2026-03-05T16:41:08.934Z
-branch: feat/add-ungroup-all
----
-
-Feat: Add Ungroup All functionality

--- a/.changeset/1772731192033-fix-changeset-script-to-only-commit-its-own-genera.md
+++ b/.changeset/1772731192033-fix-changeset-script-to-only-commit-its-own-genera.md
@@ -1,7 +1,0 @@
----
-type: chore
-date: 2026-03-05T17:19:52.033Z
-branch: chore/fix-changeset-commit
----
-
-Fix changeset script to only commit its own generated files

--- a/.changeset/1772733819912-update-status-title-to-fit-container-update-app-na.md
+++ b/.changeset/1772733819912-update-status-title-to-fit-container-update-app-na.md
@@ -1,7 +1,0 @@
----
-type: style
-date: 2026-03-05T18:03:39.912Z
-branch: chore/change-title-text
----
-
-Update status title to fit container + update app name

--- a/.changeset/1772734815117-feat-add-release-script.md
+++ b/.changeset/1772734815117-feat-add-release-script.md
@@ -1,7 +1,0 @@
----
-type: feat
-date: 2026-03-05T18:20:15.118Z
-branch: feat/release-automation
----
-
-Feat: Add release script

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "version": "1.0.0",
-      "date": "2025-01-29",
+      "version": "1.1.0",
+      "date": "2026-03-05",
       "sections": {
         "Added": [
           "Initial release of AI Tab Grouper extension",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-03-05
+
+### Added
+
+- Version bump from 1.0.0 to 1.1.0
+
+### Changed
+
+### Fixed
+
+### Security
+
+### Technical
+
 ## [1.0.0] - 2025-01-29
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Tab Grouper (Tabber)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Automatically organize Chrome tabs using AI - supports OpenAI, Claude, Groq, Gemini & Local LLMs with smart grouping",
   "homepage_url": "https://github.com/allexcd/tabber",
   "permissions": ["tabs", "tabGroups", "storage"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabber",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "description": "AI Tab Grouper - Chrome Extension",
@@ -19,6 +19,10 @@
     "version:minor": "node scripts/bump-version.js minor",
     "version:major": "node scripts/bump-version.js major",
     "version": "node scripts/bump-version.js",
+    "release:patch": "node scripts/tag-release.js patch",
+    "release:minor": "node scripts/tag-release.js minor",
+    "release:major": "node scripts/tag-release.js major",
+    "release": "node scripts/tag-release.js",
     "changeset": "node scripts/changeset.js",
     "agents": "supervisor.sh",
     "agents:reset": "supervisor.sh --reset",


### PR DESCRIPTION
## Summary
- bump app version to 1.1.0 across project files
- remove consumed changesets for the 1.1.0 release
- include generated changelog updates for v1.1.0

## Notes
- Git tag `v1.1.0` and GitHub release are already published.
- This PR is required to satisfy branch protection rules on `main`.
